### PR TITLE
Fix #15: year_sel scoping in ppl_run_pipe_dst1 and fitSpOccu

### DIFF
--- a/R/ppl_run_pipe_dst1.R
+++ b/R/ppl_run_pipe_dst1.R
@@ -123,7 +123,7 @@ ppl_run_pipe_dst1 <- function(sp_code, year, config,
 
         # Dump a message for debugging
         sink(file.path(config$out_dir, "reports", paste0(Sys.time(), "_Fitting_species_", sp_code, "_year_", year, ".txt")))
-        print(paste(Sys.time(), "Fitting occupancy model to species", sp_code, "for year", year_sel))
+        print(paste(Sys.time(), "Fitting occupancy model to species", sp_code, "for year", year))
         sink()
 
         # Fit model

--- a/R/utils-spOccupancy.R
+++ b/R/utils-spOccupancy.R
@@ -502,7 +502,7 @@ diagnoseRhatSpOccu <- function(fit, sp_code, year){
 #' @export
 #'
 #' @examples
-fitSpOccu <- function(site_data_year, visit_data_year, config, sp_code, spatial = FALSE, sp_sites, ...){
+fitSpOccu <- function(site_data_year, visit_data_year, config, sp_code, spatial = FALSE, sp_sites, year_sel, ...){
 
     # Prepare data for spOccupancy
     occu_data <- prepSpOccuData_single(site_data_year, visit_data_year, config, spatial = spatial, sp_sites)


### PR DESCRIPTION
## Summary

Two one-line fixes for the `year_sel` scoping bug reported in #15.

### ppl_run_pipe_dst1.R line 126

`year_sel` is created at line 85 inside the `"data" %in% steps` block and removed at line 90. Line 126 (inside the `"fit"` block) referenced it after removal. Changed to `year` (the function argument).

### utils-spOccupancy.R line 505

`fitSpOccu` referenced `year_sel` in its body (lines 554, 651, 658) but did not declare it as a formal parameter. `ppl_fit_occu_model.R:77` passes `year_sel` as the 7th positional argument; with only six named formals the 7th fell into `...`, where bare references cannot be resolved. Added `year_sel` as a formal before `...`.

## Test plan

- [x] Patched ppl_run_pipe_dst1.R line 126 — confirmed fit block no longer errors on "object 'year_sel' not found".
- [x] Patched utils-spOccupancy.R line 505 — confirmed `ppl_run_pipe_dst1(sp_code = 4, year = 2022, steps = c("fit","diagnose","summary"), ...)` proceeds into the spOccupancy MCMC on the BIRDIE server using cached 20_22 window inputs.
- [ ] Upstream CI (if any) — reviewers to confirm.

Closes #15.